### PR TITLE
Dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,4 +149,4 @@ pre:
 
 scrapy:
 	@echo "Running scrapy..."
-	@uv run scrapy crawl rightmove
+	@cd house/extract/rightmove && uv run scrapy crawl rightmove

--- a/house/extract/rightmove/rightmove/items.py
+++ b/house/extract/rightmove/rightmove/items.py
@@ -4,13 +4,20 @@
 # https://docs.scrapy.org/en/latest/topics/items.html
 
 import scrapy
-from itemloaders.processors import TakeFirst, Identity
+from itemloaders.processors import TakeFirst, Identity, MapCompose
+import re
+
+
+def extract_id(url):
+    """Extracts the ID from a URL."""
+    match = re.search(r"/properties/(\d+)", url)
+    return match[1] if match else None
 
 
 class RightmoveItem(scrapy.Item):
     # define the fields for your item here like:
     # name = scrapy.Field()
-    _id = scrapy.Field()
+    _id = scrapy.Field(input_processor=MapCompose(extract_id))
     accessibility = scrapy.Field(output_processor=TakeFirst())
     bathrooms = scrapy.Field(output_processor=TakeFirst())
     bedrooms = scrapy.Field(output_processor=TakeFirst())

--- a/house/extract/rightmove/rightmove/pipelines.py
+++ b/house/extract/rightmove/rightmove/pipelines.py
@@ -13,11 +13,6 @@ from itemadapter import ItemAdapter
 from scrapy.exceptions import DropItem
 
 
-class RightmovePipeline:
-    def process_item(self, item, spider):
-        return item
-
-
 class UploadToS3Pipeline:
     def __init__(self, bucket):
         self.bucket = bucket

--- a/house/extract/rightmove/rightmove/pipelines.py
+++ b/house/extract/rightmove/rightmove/pipelines.py
@@ -10,7 +10,6 @@ import boto3
 import json
 import hashlib
 from itemadapter import ItemAdapter
-from scrapy.exceptions import DropItem
 
 
 class UploadToS3Pipeline:
@@ -29,17 +28,3 @@ class UploadToS3Pipeline:
             Body=item_bytes, Bucket=self.bucket, Key=item_key + ".json"
         )
         return item
-
-
-class RemoveDuplicatesPipeline:
-    def __init__(self):
-        self.seen = set()
-
-    def process_item(self, item, spider):
-        adapter = ItemAdapter(item)
-        item_id = item.get("id")
-        if adapter["id"] in self.seen:
-            raise DropItem(f"Duplicate item found: {item_id}")
-        else:
-            self.seen.add(adapter["id"])
-            return item

--- a/house/extract/rightmove/rightmove/settings.py
+++ b/house/extract/rightmove/rightmove/settings.py
@@ -80,8 +80,7 @@ ROBOTSTXT_OBEY = True
 # See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 DOWNLOADER_MIDDLEWARES = {"scrapy_selenium.SeleniumMiddleware": 800}
 SELENIUM_DRIVER_NAME = "firefox"
-SELENIUM_DRIVER_EXECUTABLE_PATH = r"C:/Program Files/geckodriver/geckodriver.exe"
-# SELENIUM_DRIVER_EXECUTABLE_PATH = os.environ.get("SELENIUM_DRIVER_EXECUTABLE_PATH")
+SELENIUM_DRIVER_EXECUTABLE_PATH = os.environ.get("SELENIUM_DRIVER_EXECUTABLE_PATH")
 SELENIUM_DRIVER_ARGUMENTS = ["-headless"]
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html

--- a/house/extract/rightmove/rightmove/settings.py
+++ b/house/extract/rightmove/rightmove/settings.py
@@ -30,19 +30,12 @@ ADDONS = {}
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
-# FEEDS = {
-#     "s3://aws_key:aws_secret@quibbler-house-data-lake/%(name)s_batch_%(batch_time)s.csv": {
-#         "format": "csv",
-#         "encoding": "utf8",
-#         "store_empty": False,
-#         "fields": None,
-#         "indent": 4,
-#         "item_export_kwargs": {
-#             "export_empty_fields": True,
-#         },
-#         "batch_item_count": 10000,
-#     }
-# }
+FEED_EXPORT_BATCH_ITEM_COUNT = 1000
+FEEDS = {
+    "s3://quibbler-house-data-lake/%(name)s_batch_%(batch_time)s.csv": {
+        "format": "csv",
+    }
+}
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 # USER_AGENT = "rightmove (+http://www.yourdomain.com)"
 
@@ -95,10 +88,10 @@ SELENIUM_DRIVER_ARGUMENTS = ["-headless"]
 
 # Configure item pipelines
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
-# ITEM_PIPELINES = {
-# "rightmove.pipelines.UploadToS3Pipeline": 2,
-# "rightmove.pipelines.RemoveDuplicatesPipeline": 1,
-# }
+ITEM_PIPELINES = {
+    # "rightmove.pipelines.UploadToS3Pipeline": 2,
+    # "rightmove.pipelines.RemoveDuplicatesPipeline": 1,
+}
 
 AWS_S3_BUCKET = "quibbler-house-data-lake"
 # Enable and configure the AutoThrottle extension (disabled by default)

--- a/house/extract/rightmove/rightmove/settings.py
+++ b/house/extract/rightmove/rightmove/settings.py
@@ -67,20 +67,22 @@ ROBOTSTXT_OBEY = True
 # TELNETCONSOLE_ENABLED = False
 
 # Override the default request headers:
-DEFAULT_REQUEST_HEADERS = {
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
-    "Accept-Language": "en-GB,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,en-US;q=0.6",
-    "Accept-Encoding": "gzip, deflate, zstd",
-    "Connection": "keep-alive",
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
-    "Host": "www.rightmove.co.uk",
-}
+# DEFAULT_REQUEST_HEADERS = {
+#     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+#     "Accept-Language": "en-GB,en;q=0.9,zh-CN;q=0.8,zh;q=0.7,en-US;q=0.6",
+#     "Accept-Encoding": "gzip, deflate, zstd",
+#     "Connection": "keep-alive",
+#     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+#     "Host": "www.rightmove.co.uk",
+# }
 
 # Enable or disable spider middlewares
 # See https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 DOWNLOADER_MIDDLEWARES = {"scrapy_selenium.SeleniumMiddleware": 800}
 SELENIUM_DRIVER_NAME = "firefox"
-SELENIUM_DRIVER_EXECUTABLE_PATH = os.environ.get("SELENIUM_DRIVER_EXECUTABLE_PATH")
+SELENIUM_DRIVER_EXECUTABLE_PATH = r"C:/Program Files/geckodriver/geckodriver.exe"
+# SELENIUM_DRIVER_EXECUTABLE_PATH = os.environ.get("SELENIUM_DRIVER_EXECUTABLE_PATH")
+SELENIUM_DRIVER_ARGUMENTS = ["-headless"]
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 #    "rightmove.middlewares.RightmoveDownloaderMiddleware": 2,
@@ -95,9 +97,8 @@ SELENIUM_DRIVER_EXECUTABLE_PATH = os.environ.get("SELENIUM_DRIVER_EXECUTABLE_PAT
 # Configure item pipelines
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 # ITEM_PIPELINES = {
-#     "rightmove.pipelines.RightmovePipeline": 1,
-#     "rightmove.pipelines.UploadToS3Pipeline": 3,
-#     "rightmove.pipelines.RemoveDuplicatesPipeline": 2,
+# "rightmove.pipelines.UploadToS3Pipeline": 2,
+# "rightmove.pipelines.RemoveDuplicatesPipeline": 1,
 # }
 
 AWS_S3_BUCKET = "quibbler-house-data-lake"

--- a/house/extract/rightmove/rightmove/spiders/rightmove.py
+++ b/house/extract/rightmove/rightmove/spiders/rightmove.py
@@ -54,6 +54,7 @@ class RightmoveSpider(SitemapSpider):
 
     def parse(self, response):
         loader = ItemLoader(item=RightmoveItem(), response=response)
+        loader.add_xpath("_id", '//link[@rel="canonical"]/@href')
         loader.add_xpath("url", '//link[@rel="canonical"]/@href')
         loader.add_xpath("price", "//article/div/div/div/span[1]/text()")
         loader.add_xpath("title", "//h1/text()")

--- a/house/extract/rightmove/rightmove/spiders/rightmove.py
+++ b/house/extract/rightmove/rightmove/spiders/rightmove.py
@@ -1,8 +1,12 @@
 import logging
-import scrapy
-import scrapy.spiders
+
+from scrapy.spiders import SitemapSpider
+from scrapy.http import Request, Response
+from scrapy.spiders.sitemap import iterloc
+from collections.abc import Iterable
 from scrapy.loader import ItemLoader
 from scrapy_selenium import SeleniumRequest
+from scrapy.utils.sitemap import Sitemap, sitemap_urls_from_robots
 
 from house.extract.rightmove.rightmove.items import RightmoveItem
 
@@ -10,31 +14,45 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-class RightmoveSpider(scrapy.spiders.CrawlSpider):
+class RightmoveSpider(SitemapSpider):
     """
     rightmove
     """
 
     name = "rightmove"
-    start_urls = [
-        "https://www.rightmove.co.uk/properties/163226654",
-        "https://www.rightmove.co.uk/properties/164658461",
+
+    sitemap_urls = ["https://www.rightmove.co.uk/sitemap.xml"]
+    sitemap_rules = [
+        (r"/properties/\d+", "parse"),
     ]
 
-    # def start_requests(self):
-    #     url = "https://www.rightmove.co.uk/properties/163477127"
-    #     yield SeleniumRequest(url=url, callback=self.parse_property)
-    def start_requests(self):
-        for url in self.start_urls:
-            yield SeleniumRequest(url=url, callback=self.parse)
+    def _parse_sitemap(self, response: Response) -> Iterable[Request]:
+        if response.url.endswith("/robots.txt"):
+            for url in sitemap_urls_from_robots(response.text, base_url=response.url):
+                yield Request(url, callback=self._parse_sitemap)
+        else:
+            body = self._get_sitemap_body(response)
+            if body is None:
+                logger.warning(
+                    "Ignoring invalid sitemap: %(response)s",
+                    {"response": response},
+                    extra={"spider": self},
+                )
+                return
+            s = Sitemap(body)
+            it = self.sitemap_filter(s)
+            if s.type == "sitemapindex":
+                for loc in iterloc(it, self.sitemap_alternate_links):
+                    if any(x.search(loc) for x in self._follow):
+                        yield Request(loc, callback=self._parse_sitemap)
+            elif s.type == "urlset":
+                for loc in iterloc(it, self.sitemap_alternate_links):
+                    for r, c in self._cbs:
+                        if r.search(loc):
+                            yield SeleniumRequest(url=loc, callback=c)
+                            break
 
     def parse(self, response):
-        # options = webdriver.FirefoxOptions()
-        # driver = webdriver.Firefox(options=options)
-        # driver.get(self.start_urls[0])
-        # driver.implicitly_wait(10)
-        # response = driver.page_source
-        # selector = Selector(text=response)
         loader = ItemLoader(item=RightmoveItem(), response=response)
         loader.add_xpath("url", '//link[@rel="canonical"]/@href')
         loader.add_xpath("price", "//article/div/div/div/span[1]/text()")
@@ -58,62 +76,3 @@ class RightmoveSpider(scrapy.spiders.CrawlSpider):
             "//a[@rel=\"nofollow\"]/img[starts-with(@src, 'https://media.rightmove.co.uk')]/@src",
         )
         yield loader.load_item()
-
-    # def parse(self, response):
-    #     # Extract the outcode from the URL
-    #     headers = {
-    #         "Accept": "*/*",
-    #         "Accept-Encoding": "gzip, deflate, br",
-    #         "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
-    #         "Connection": "keep-alive",
-    #         "Host": "www.rightmove.co.uk",
-    #     }
-    #     let_or_sales = "sales" if "property-to-rent" in response.url else "rent"
-    #     homes = response.css('[class^="PropertyCard_propertyCardContainer_"]')
-    #     if not homes:
-    #         logger.debug(f"Ignoring no items response for URL: {response.url}")
-    #         return
-    #     for home in homes:
-    #         loader = RightmoveItemLoader(item=RightmoveItem(), selector=home)
-    #         loader.add_css("url", "a.propertyCard-link::attr(href)")
-    #         loader.add_css("price", '[class^="PropertyPrice_price_"]::text')
-    #         loader.add_xpath("title", ".//address/text()")
-    #         loader.add_css("date_added", '[class^="MarketedBy_joinedText_"]::text')
-    #         loader.add_css(
-    #             "property_type", '[class^="PropertyInformation_propertyType_"]::text'
-    #         )
-    #         loader.add_css(
-    #             "bedrooms", '[class^="PropertyInformation_bedroomsCount_"]::text'
-    #         )
-    #         loader.add_css(
-    #             "bathrooms", '[class^="PropertyInformation_bathContainer_"] span::text'
-    #         )
-    #         loader.add_css(
-    #             "phone",
-    #             '[class^="CallAgent_test_"] > a:nth-child(2) > span:nth-child(1)::text',
-    #         )
-    #         loader.add_css("address", '[class^="PropertyAddress_address_"]::text')
-    #         loader.add_css("summary", '[class^="PropertyCardSummary_summary_"]::text')
-    #         loader.add_css("email", '[class^="Contact_emailLink_"]::attr(href)')
-    #         loader.add_value("catalog_url", response.url)
-    #         loader.add_value("let_or_sales", let_or_sales)
-    #         yield loader.load_item()
-    #     total = int(
-    #         response.css('[class^="ResultsCount_resultsCount_"] p span::text')
-    #         .get()
-    #         .replace(",", "")
-    #     )
-    #     logger.debug(f"Total properties found: {total}")
-    #     current_index = (
-    #         int(parse_qs(urlparse(response.url).query).get("index", [None])[0]) + 24
-    #         if "index" in response.url
-    #         else 24
-    #     )
-    #     next_page = update_param(response.url, "index", current_index)
-    #     logger.debug(f"Next page URL: {next_page}")
-    #     yield scrapy.Request(
-    #         method="GET",
-    #         url=next_page,
-    #         headers=headers,
-    #         callback=self.parse,
-    #     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ default-groups = [
     "docs",
 ]
 
+[tool.uv.sources]
+scrapy-selenium = { git = "https://github.com/jogobeny/scrapy-selenium" }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "fire>=0.7.0",
     "scrapy-selenium>=0.0.7",
     "selenium>=4.34.2",
+    "botocore>=1.40.8",
+    "boto3>=1.40.8",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
fix #52

## Summary by Sourcery

Use sitemap-based crawling to discover Rightmove property listings, extract IDs from URLs, and streamline project configuration and dependencies

New Features:
- Switch to SitemapSpider with custom sitemap parsing to dynamically discover property URLs
- Add input processor to extract property IDs from URLs in RightmoveItem

Bug Fixes:
- Fix property URL discovery by parsing sitemaps and robots.txt to address missing listings

Enhancements:
- Simplify FEEDS configuration for S3 CSV export with batch export size and remove inline credentials
- Enable headless Selenium and streamline downloader middleware settings
- Remove unused pipelines and clean up commented code in the spider and pipelines
- Update Makefile to run scrapy from the correct subdirectory
- Add botocore and boto3 dependencies and configure scrapy-selenium source in pyproject.toml